### PR TITLE
Change vendor name to conform to the standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "MiWayInsurance/vehicle-provider",
+  "name": "miway/vehicle-provider",
   "description": "3rd party vehicle provider for fzaninotto/Faker",
   "keywords": [
     "faker",


### PR DESCRIPTION
The vendor name should be all lowercase characters, and we use `miway` in other packages as opposed to `MiWayInsurance`